### PR TITLE
chore: bump known vulnerable dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "gatsby-source-contentful": "^2.0.48",
     "gatsby-transformer-remark": "^2.3.8",
     "gatsby-transformer-sharp": "^2.1.18",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.21",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-helmet": "^5.2.0",
@@ -31,7 +31,7 @@
     "inquirer": "^6.2.2",
     "prettier": "^1.17.0",
     "rimraf": "^2.6.3",
-    "yargs-parser": "^13.0.0"
+    "yargs-parser": "^13.1.2"
   },
   "homepage": "https://github.com/contentful-userland/gatsby-contentful-starter#readme",
   "keywords": [


### PR DESCRIPTION
### Motivation
- Address known security issues by updating vulnerable packages `lodash` and `yargs-parser` to non-vulnerable releases.

### Description
- Updated `package.json` to set `lodash` to `^4.17.21` in `dependencies` and `yargs-parser` to `^13.1.2` in `devDependencies`.

### Testing
- Attempted `npm audit --json`, `yarn npm audit` and `npm install` which failed due to registry/advisory `403 Forbidden` in this environment, and verified `package.json` parses successfully with `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8'))"`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ea4d78fd88332ad05c79bd175d938)